### PR TITLE
#52 feat: 入庫記録モーダル・CSV出力・Profile画面を移植

### DIFF
--- a/apps/api/src/routes/items.test.ts
+++ b/apps/api/src/routes/items.test.ts
@@ -201,3 +201,98 @@ describe('PUT /api/items/:id', () => {
     expect(res.status).toBe(422);
   });
 });
+
+describe('POST /api/items/bulk', () => {
+  it('文字列 inventoryItem のまま登録され stock_ins には記録されない(現行仕様)', async () => {
+    const res = await app.request('/api/items/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({
+        items: [
+          {
+            productName: `${MARK}バルク`,
+            modelNumber: 'BULK-1',
+            location: 'バルク倉庫',
+            inventoryItem: '77',
+            remarks: 'カンマ入力',
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: 'アイテムが正常に登録されました。' });
+
+    const [row] = await db
+      .select()
+      .from(items)
+      .where(eq(items.productName, `${MARK}バルク`));
+    expect(row?.inventoryItem).toBe(77);
+    if (!row) throw new Error('bulk row not created');
+    const ins = await db.select().from(stockIns).where(eq(stockIns.itemId, row.id));
+    expect(ins.length).toBe(0);
+  });
+});
+
+describe('POST /api/items/csv', () => {
+  it('BOM 付き・laracsv 互換ヘッダ・選択行のみの CSV を返す', async () => {
+    const res = await app.request('/api/items/csv', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ ids: [String(itemId)], fileName: '202607_棚卸し.csv' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/csv');
+    const encoded = encodeURIComponent('202607_棚卸し.csv');
+    expect(res.headers.get('content-disposition')).toBe(
+      `attachment; filename="${encoded}"; filename*=UTF-8''${encoded}`,
+    );
+
+    const text = await res.text();
+    expect(text.startsWith('﻿')).toBe(true);
+    const lines = text.slice(1).trimEnd().split('\n');
+    expect(lines[0]).toBe('ID,商品名,型番,場所,在庫数,備考,登録日');
+    expect(lines.length).toBe(2);
+    expect(lines[1]).toBe(
+      `${itemId},${MARK}商品,PR4-MODEL,PR4-倉庫,8,PR4 テスト,2026-01-01 00:00:00`,
+    );
+  });
+
+  it('ids 空はヘッダのみの CSV(現行仕様)', async () => {
+    const res = await app.request('/api/items/csv', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ fileName: 'empty.csv' }),
+    });
+
+    const text = await res.text();
+    expect(text).toBe('﻿ID,商品名,型番,場所,在庫数,備考,登録日\n');
+  });
+
+  it('カンマを含む備考はクオートされる', async () => {
+    const [inserted] = await db
+      .insert(items)
+      .values({
+        productName: `${MARK}カンマ`,
+        modelNumber: 'C-1',
+        location: 'L-1',
+        inventoryItem: 1,
+        quantityChange: 0,
+        remarks: 'a,b "q"',
+        createdAt: '2026-01-02 03:04:05',
+        updatedAt: '2026-01-02 03:04:05',
+      })
+      .returning({ id: items.id });
+    if (!inserted) throw new Error('failed to insert');
+
+    const res = await app.request('/api/items/csv', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ ids: [inserted.id], fileName: 'q.csv' }),
+    });
+    const text = await res.text();
+    expect(text).toContain('"a,b ""q"""');
+    expect(text).toContain('2026-01-02 03:04:05');
+  });
+});

--- a/apps/api/src/routes/items.test.ts
+++ b/apps/api/src/routes/items.test.ts
@@ -254,8 +254,11 @@ describe('POST /api/items/csv', () => {
     const lines = text.slice(1).trimEnd().split('\n');
     expect(lines[0]).toBe('ID,商品名,型番,場所,在庫数,備考,登録日');
     expect(lines.length).toBe(2);
+    // 先行テストの副作用に依存しないよう、期待値は DB の現在値から動的に組み立てる
+    const [current] = await db.select().from(items).where(eq(items.id, itemId));
+    if (!current) throw new Error('test item missing');
     expect(lines[1]).toBe(
-      `${itemId},${MARK}商品,PR4-MODEL,PR4-倉庫,8,PR4 テスト,2026-01-01 00:00:00`,
+      `${itemId},${current.productName},${current.modelNumber},${current.location},${current.inventoryItem},${current.remarks},2026-01-01 00:00:00`,
     );
   });
 

--- a/apps/api/src/routes/items.ts
+++ b/apps/api/src/routes/items.ts
@@ -1,5 +1,5 @@
 import { zValidator } from '@hono/zod-validator';
-import { count, eq } from 'drizzle-orm';
+import { count, eq, inArray } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { db } from '../db';
@@ -44,6 +44,16 @@ const listQuerySchema = z.object({
   per_page: z.coerce.number().int().positive().optional(),
   page: z.coerce.number().int().positive().optional(),
 });
+
+/** CSV フィールドの RFC4180 風クオート(league/csv 互換)。 */
+const csvField = (value: string | number | null): string => {
+  const s = value === null ? '' : String(value);
+  return /[",\n\r]/.test(s) ? `"${s.replaceAll('"', '""')}"` : s;
+};
+
+/** CSV の登録日は Laravel(Carbon の __toString)と同じ 'YYYY-MM-DD HH:mm:ss'。 */
+const toCsvTimestamp = (value: string | null): string =>
+  value === null ? '' : value.replace('T', ' ').slice(0, 19);
 
 const updateSchema = z.object({
   productName: z.preprocess(emptyToNull, z.string()),
@@ -91,6 +101,69 @@ export const itemRoutes = new Hono<AuthEnv>()
       });
     },
   )
+  .post('/bulk', async (c) => {
+    // 現行 insItemBulk の忠実移植: バリデーションなし・stock_ins への記録なし・
+    // トランザクションなし(途中失敗で部分登録が残るのも現行仕様)。
+    // inventoryItem は文字列のまま届く(PostgreSQL のパラメータ変換に委ねる)
+    const body = (await c.req.json()) as {
+      items?: Array<{
+        productName: string;
+        modelNumber: string;
+        location: string;
+        inventoryItem: number | string;
+        remarks: string | null;
+      }>;
+    };
+    const bulkItems = body.items ?? [];
+    for (const itemData of bulkItems) {
+      const now = nowTimestamp();
+      await db.insert(items).values({
+        productName: itemData.productName,
+        modelNumber: itemData.modelNumber,
+        location: itemData.location,
+        inventoryItem: itemData.inventoryItem as number,
+        remarks: itemData.remarks,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+    return c.json({ success: 'アイテムが正常に登録されました。' });
+  })
+  .post('/csv', async (c) => {
+    // 現行 csv アクションの忠実移植(migration-spec.md §3.2)。
+    // fileName は現行同様に未検証のまま Content-Disposition へ渡す(既知の課題として仕様書に記載済み)
+    const body = (await c.req.json()) as { ids?: Array<string | number>; fileName?: string };
+    const ids = (body.ids ?? []).map(Number);
+    const fileName = body.fileName ?? '';
+
+    const rows = ids.length > 0 ? await db.select().from(items).where(inArray(items.id, ids)) : [];
+
+    const header = ['ID', '商品名', '型番', '場所', '在庫数', '備考', '登録日'];
+    const lines = [
+      header.join(','),
+      ...rows.map((row) =>
+        [
+          csvField(row.id),
+          csvField(row.productName),
+          csvField(row.modelNumber),
+          csvField(row.location),
+          csvField(row.inventoryItem),
+          csvField(row.remarks),
+          csvField(toCsvTimestamp(row.createdAt)),
+        ].join(','),
+      ),
+    ];
+    const csv = `\uFEFF${lines.join('\n')}\n`;
+
+    // fetch 標準の Headers は非 ASCII を受け付けない(現行 Laravel は生 UTF-8 だが
+    // ランタイム制約で不可能)。フロントは download 属性のクライアント側ファイル名を
+    // 使うため実害はなく、RFC 6266 の filename* 形式でエンコードして返す
+    const encodedFileName = encodeURIComponent(fileName);
+    return c.body(csv, 200, {
+      'Content-Type': 'text/csv; charset=UTF-8',
+      'Content-Disposition': `attachment; filename="${encodedFileName}"; filename*=UTF-8''${encodedFileName}`,
+    });
+  })
   .put(
     '/:id',
     zValidator('json', updateSchema, (result, c) => {

--- a/apps/web/src/components/StorageRegister.test.tsx
+++ b/apps/web/src/components/StorageRegister.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { StorageRegister } from './StorageRegister';
+
+const mockBulkPost = vi.hoisted(() => vi.fn());
+
+vi.mock('../lib/api-client', () => ({
+  api: { api: { items: { bulk: { $post: mockBulkPost } } } },
+}));
+
+describe('StorageRegister', () => {
+  beforeEach(() => {
+    mockBulkPost.mockReset();
+  });
+
+  it('カンマ区切り入力を1件の配列(inventoryItem は文字列)として送信し成功メッセージを表示する', async () => {
+    mockBulkPost.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: 'アイテムが正常に登録されました。' }),
+    });
+    const user = userEvent.setup();
+    render(<StorageRegister isOpen={true} onClose={() => {}} fetchData={() => {}} />);
+
+    await user.type(
+      screen.getByPlaceholderText('例:サーバー,DL360,櫻井倉庫,100,代理名'),
+      'サーバー, DL360 ,櫻井倉庫,100,代理名',
+    );
+    await user.click(screen.getByRole('button', { name: '一括登録' }));
+
+    expect(mockBulkPost).toHaveBeenCalledWith({
+      json: {
+        items: [
+          {
+            productName: 'サーバー',
+            modelNumber: 'DL360',
+            location: '櫻井倉庫',
+            inventoryItem: '100',
+            remarks: '代理名',
+          },
+        ],
+      },
+    });
+    expect(await screen.findByText('アイテムが正常に登録されました。')).toBeInTheDocument();
+  });
+
+  it('失敗時は console.error のみで画面は変わらない(現行仕様)', async () => {
+    mockBulkPost.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const user = userEvent.setup();
+    render(<StorageRegister isOpen={true} onClose={() => {}} fetchData={() => {}} />);
+
+    await user.type(
+      screen.getByPlaceholderText('例:サーバー,DL360,櫻井倉庫,100,代理名'),
+      'a,b,c,1,d',
+    );
+    await user.click(screen.getByRole('button', { name: '一括登録' }));
+
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(screen.queryByText(/正常に登録/)).not.toBeInTheDocument();
+    consoleSpy.mockRestore();
+  });
+});

--- a/apps/web/src/components/StorageRegister.tsx
+++ b/apps/web/src/components/StorageRegister.tsx
@@ -1,0 +1,71 @@
+import type React from 'react';
+import { useBulkData } from '../features/BulkRegister';
+import { Modal } from './Modal';
+
+interface StorageRegisterProps {
+  isOpen: boolean;
+  onClose: () => void;
+  fetchData: () => void;
+}
+
+/**
+ * 入庫記録モーダル(現行 Pages/Layouts/StorageRegister.tsx の忠実移植)。
+ * 入力欄は単一行 input(改行入力不可 = 常に 1 件送信、migration-spec.md §2.3)。
+ * 独立ページとしてのルートは現行でも成立していないため作らない(§2.3 ⚠️C)。
+ */
+export const StorageRegister: React.FC<StorageRegisterProps> = ({ isOpen, onClose }) => {
+  const { bulkData, setBulkData, bulkHandleSubmit, successMessage } = useBulkData();
+
+  return (
+    <Modal show={isOpen} onClose={onClose}>
+      <div className="relative">
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-3 top-3 text-white text-2xl h-8 w-8 flex items-center justify-center bg-transparent hover:bg-gray-500 rounded-full"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth="2"
+            width="24"
+            height="24"
+          >
+            <title>閉じる</title>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+        <form onSubmit={bulkHandleSubmit}>
+          <table className="w-full border-4 border-lightblue bg-deepblue h-auto">
+            <tbody>
+              <tr>
+                <td className="py-3 px-4 flex flex-col items-center justify-center">
+                  <label htmlFor="taskDetail" className="text-red-600 mr-4">
+                    ※商品名,型番,納品場所,入庫数量,備考をカンマ区切りで入力すると一括登録されます。
+                  </label>
+                  <p className="text-white">例:サーバー,DL360,櫻井倉庫,100,代理名</p>
+                  <input
+                    type="text"
+                    value={bulkData}
+                    onChange={(e) => setBulkData(e.target.value)}
+                    placeholder="例:サーバー,DL360,櫻井倉庫,100,代理名"
+                    className="border p-2 w-full mb-8 mt-10"
+                  />
+                  <button
+                    type="submit"
+                    className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded float-right mb-10 mt-4"
+                  >
+                    一括登録
+                  </button>
+                  {successMessage && <div className="mt-4 text-green-500">{successMessage}</div>}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </form>
+      </div>
+    </Modal>
+  );
+};

--- a/apps/web/src/components/TextInput.tsx
+++ b/apps/web/src/components/TextInput.tsx
@@ -1,13 +1,29 @@
-import { type InputHTMLAttributes, useEffect, useRef } from 'react';
+import { type InputHTMLAttributes, type Ref, useEffect, useRef } from 'react';
 
-/** Breeze の TextInput の移植。isFocused でマウント時にフォーカスする。 */
+/**
+ * Breeze の TextInput の移植。isFocused でマウント時にフォーカスする。
+ * React 19 の ref-as-prop で外部 ref(エラー時フォーカス移動用)も受け付ける。
+ */
 export function TextInput({
   type = 'text',
   className = '',
   isFocused = false,
+  ref,
   ...props
-}: InputHTMLAttributes<HTMLInputElement> & { isFocused?: boolean }) {
-  const localRef = useRef<HTMLInputElement>(null);
+}: InputHTMLAttributes<HTMLInputElement> & {
+  isFocused?: boolean;
+  ref?: Ref<HTMLInputElement>;
+}) {
+  const localRef = useRef<HTMLInputElement | null>(null);
+
+  const setRefs = (el: HTMLInputElement | null) => {
+    localRef.current = el;
+    if (typeof ref === 'function') {
+      ref(el);
+    } else if (ref) {
+      ref.current = el;
+    }
+  };
 
   useEffect(() => {
     if (isFocused) {
@@ -20,7 +36,7 @@ export function TextInput({
       {...props}
       type={type}
       className={`border-lightblue rounded-md shadow-sm focus:border-lightblue focus:ring-lightblue ${className}`}
-      ref={localRef}
+      ref={setRefs}
     />
   );
 }

--- a/apps/web/src/components/UpdatePasswordForm.test.tsx
+++ b/apps/web/src/components/UpdatePasswordForm.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UpdatePasswordForm } from './UpdatePasswordForm';
+
+const mockChangePassword = vi.hoisted(() => vi.fn());
+
+vi.mock('../lib/auth-client', () => ({
+  authClient: { changePassword: mockChangePassword },
+}));
+
+const fill = async (
+  user: ReturnType<typeof userEvent.setup>,
+  current: string,
+  next: string,
+  confirm: string,
+) => {
+  await user.type(screen.getByLabelText('旧パスワード'), current);
+  await user.type(screen.getByLabelText('新しいパスワード'), next);
+  await user.type(screen.getByLabelText('新しいパスワード(確認用)'), confirm);
+  await user.click(screen.getByRole('button', { name: '保存' }));
+};
+
+describe('UpdatePasswordForm', () => {
+  beforeEach(() => {
+    mockChangePassword.mockReset();
+  });
+
+  it('確認用パスワード不一致はクライアント側でエラー表示し API を呼ばない', async () => {
+    const user = userEvent.setup();
+    render(<UpdatePasswordForm />);
+
+    await fill(user, 'old-pass', 'new-pass-1234', 'different');
+
+    expect(
+      await screen.findByText('The password confirmation does not match.'),
+    ).toBeInTheDocument();
+    expect(mockChangePassword).not.toHaveBeenCalled();
+  });
+
+  it('現在のパスワード誤りは旧パスワード欄にエラーを表示する', async () => {
+    mockChangePassword.mockResolvedValue({
+      data: null,
+      error: { code: 'INVALID_PASSWORD', message: 'Invalid password' },
+    });
+    const user = userEvent.setup();
+    render(<UpdatePasswordForm />);
+
+    await fill(user, 'wrong-old', 'new-pass-1234', 'new-pass-1234');
+
+    expect(await screen.findByText('The password is incorrect.')).toBeInTheDocument();
+  });
+
+  it('成功時は「パスワード更新されました」を表示しフォームをリセットする', async () => {
+    mockChangePassword.mockResolvedValue({ data: {}, error: null });
+    const user = userEvent.setup();
+    render(<UpdatePasswordForm />);
+
+    await fill(user, 'old-pass', 'new-pass-1234', 'new-pass-1234');
+
+    expect(await screen.findByText('パスワード更新されました')).toBeInTheDocument();
+    expect(mockChangePassword).toHaveBeenCalledWith({
+      currentPassword: 'old-pass',
+      newPassword: 'new-pass-1234',
+    });
+    expect(screen.getByLabelText('旧パスワード')).toHaveValue('');
+  });
+});

--- a/apps/web/src/components/UpdatePasswordForm.tsx
+++ b/apps/web/src/components/UpdatePasswordForm.tsx
@@ -1,0 +1,138 @@
+import { Transition } from '@headlessui/react';
+import { type FormEventHandler, useRef, useState } from 'react';
+import { authClient } from '../lib/auth-client';
+import { InputError } from './InputError';
+import { InputLabel } from './InputLabel';
+import { PrimaryButton } from './PrimaryButton';
+import { TextInput } from './TextInput';
+
+interface FormErrors {
+  current_password?: string;
+  password?: string;
+  password_confirmation?: string;
+}
+
+/**
+ * パスワード変更フォーム(Breeze UpdatePasswordForm の移植、migration-spec.md §2.4)。
+ * バックエンドは Better Auth の change-password に置換。確認用パスワードの一致検証は
+ * クライアント側で行い、エラー文言は現行(Laravel 既定の英語)を踏襲する。
+ * エラー時のフィールドリセット+フォーカス移動も現行同様。
+ */
+export function UpdatePasswordForm({ className = '' }: { className?: string }) {
+  const passwordInput = useRef<HTMLInputElement>(null);
+  const currentPasswordInput = useRef<HTMLInputElement>(null);
+
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [password, setPassword] = useState('');
+  const [passwordConfirmation, setPasswordConfirmation] = useState('');
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [processing, setProcessing] = useState(false);
+  const [recentlySuccessful, setRecentlySuccessful] = useState(false);
+
+  const updatePassword: FormEventHandler = async (e) => {
+    e.preventDefault();
+    setErrors({});
+    setRecentlySuccessful(false);
+
+    if (password !== passwordConfirmation) {
+      setErrors({ password: 'The password confirmation does not match.' });
+      setPassword('');
+      setPasswordConfirmation('');
+      passwordInput.current?.focus();
+      return;
+    }
+
+    setProcessing(true);
+    const { error } = await authClient.changePassword({
+      currentPassword,
+      newPassword: password,
+    });
+    setProcessing(false);
+
+    if (error) {
+      if (error.code === 'INVALID_PASSWORD') {
+        setErrors({ current_password: 'The password is incorrect.' });
+        setCurrentPassword('');
+        currentPasswordInput.current?.focus();
+      } else {
+        // 文字数不足など(Better Auth 既定は 8 文字以上)
+        setErrors({ password: error.message ?? 'The password is invalid.' });
+        setPassword('');
+        setPasswordConfirmation('');
+        passwordInput.current?.focus();
+      }
+      return;
+    }
+
+    setCurrentPassword('');
+    setPassword('');
+    setPasswordConfirmation('');
+    setRecentlySuccessful(true);
+  };
+
+  return (
+    <section className={className}>
+      <form onSubmit={updatePassword} className="mt-6 space-y-6">
+        <Transition
+          show={recentlySuccessful}
+          enter="transition ease-in-out"
+          enterFrom="opacity-0"
+          leave="transition ease-in-out"
+          leaveTo="opacity-0"
+        >
+          <p className="text-sm text-red-600">パスワード更新されました</p>
+        </Transition>
+        <div>
+          <InputLabel htmlFor="current_password" value="旧パスワード" />
+
+          <TextInput
+            id="current_password"
+            ref={currentPasswordInput}
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            type="password"
+            className="mt-1 block w-full"
+            autoComplete="current-password"
+          />
+
+          <InputError message={errors.current_password} className="mt-2" />
+        </div>
+
+        <div>
+          <InputLabel htmlFor="password" value="新しいパスワード" />
+
+          <TextInput
+            id="password"
+            ref={passwordInput}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            type="password"
+            className="mt-1 block w-full"
+            autoComplete="new-password"
+          />
+
+          <InputError message={errors.password} className="mt-2" />
+        </div>
+
+        <div>
+          <InputLabel htmlFor="password_confirmation" value="新しいパスワード(確認用)" />
+
+          <TextInput
+            id="password_confirmation"
+            value={passwordConfirmation}
+            onChange={(e) => setPasswordConfirmation(e.target.value)}
+            type="password"
+            className="mt-1 block w-full"
+            autoComplete="new-password"
+          />
+
+          <InputError message={errors.password_confirmation} className="mt-2" />
+        </div>
+
+        <div className="flex items-center gap-4">
+          <PrimaryButton disabled={processing}>保存</PrimaryButton>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/src/components/UpdatePasswordForm.tsx
+++ b/apps/web/src/components/UpdatePasswordForm.tsx
@@ -68,6 +68,8 @@ export function UpdatePasswordForm({ className = '' }: { className?: string }) {
     setPassword('');
     setPasswordConfirmation('');
     setRecentlySuccessful(true);
+    // Inertia useForm の recentlySuccessful は 2 秒で自動消去される。同挙動を再現
+    setTimeout(() => setRecentlySuccessful(false), 2000);
   };
 
   return (

--- a/apps/web/src/features/BulkRegister.ts
+++ b/apps/web/src/features/BulkRegister.ts
@@ -1,0 +1,36 @@
+import type React from 'react';
+import { useInventoryItemState } from '../hooks/InventoryItems';
+import { api } from '../lib/api-client';
+
+/**
+ * 一括入庫登録(現行 features/BulkRegister.tsx の忠実移植)。
+ * 改行分割ロジックはコード上残るが、入力欄が単一行 input のため UI からは常に
+ * 1 件のみ送信される(migration-spec.md §2.3)。inventoryItem は文字列のまま送る。
+ */
+export const useBulkData = () => {
+  const { bulkData, setBulkData } = useInventoryItemState();
+  const { successMessage, setSuccessMessage } = useInventoryItemState();
+
+  const bulkHandleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      const bulkItems = bulkData.split('\n').map((line) => {
+        const [productName, modelNumber, location, inventoryItem, remarks] = line
+          .split(',')
+          .map((part) => part.trim());
+        return { productName, modelNumber, location, inventoryItem, remarks };
+      });
+      const response = await api.api.items.bulk.$post({
+        json: { items: bulkItems },
+      });
+      if (!response.ok) {
+        throw new Error(`Request failed with status code ${response.status}`);
+      }
+      const data = (await response.json()) as { success: string };
+      setSuccessMessage(data.success);
+    } catch (error) {
+      console.error('Error posting bulk items:', error);
+    }
+  };
+  return { bulkData, setBulkData, bulkHandleSubmit, successMessage };
+};

--- a/apps/web/src/features/DownloadCsv.ts
+++ b/apps/web/src/features/DownloadCsv.ts
@@ -1,16 +1,50 @@
 import type React from 'react';
+import { useInventoryItemState } from '../hooks/InventoryItems';
+import { api } from '../lib/api-client';
 
 /**
- * CSV ダウンロード(PR5 で移植予定のスタブ)。
- * 現行 features/DownloadCsv.tsx の POST /api/items/csv 呼び出しは
- * API 側の実装(PR5)と合わせて移植する。
+ * CSV ダウンロード(現行 features/DownloadCsv.tsx の忠実移植)。
+ * - ファイル名の年月は UTC 基準(JST では毎月1日 0:00〜8:59 に前月表記 — 現行仕様)
+ * - 選択 0 件・失敗時のエラーメッセージは state にセットされるだけで画面には出ない(現行仕様)
  */
 export const useDownloadCsv = (
-  _checkBox: { [key: string]: boolean },
+  checkBox: { [key: string]: boolean },
   _setCheckBox: React.Dispatch<React.SetStateAction<{ [key: string]: boolean }>>,
 ) => {
-  const handleDownloadCsv = () => {
-    console.warn('CSV ダウンロードは PR5 で移植予定');
+  const { errorMessage, setErrorMessage } = useInventoryItemState();
+  const yearMonth = new Date().toISOString().slice(0, 7).replace('-', '');
+  const csvFileName = `${yearMonth}_棚卸し.csv`;
+
+  const handleDownloadCsv = async () => {
+    try {
+      const selectedIds = Object.keys(checkBox).filter((key) => checkBox[key]);
+      if (selectedIds.length === 0) {
+        setErrorMessage('エラー: 選択されたアイテムがありません。');
+        return;
+      }
+      const response = await api.api.items.csv.$post({
+        json: { ids: selectedIds, fileName: csvFileName },
+      });
+      if (!response.ok) {
+        throw new Error(`Request failed with status code ${response.status}`);
+      }
+      const blob = await response.blob();
+
+      const url = window.URL.createObjectURL(new Blob([blob]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', `${csvFileName}`);
+      document.body.appendChild(link);
+      link.click();
+      if (link.parentNode) {
+        link.parentNode.removeChild(link);
+      }
+      setErrorMessage('');
+    } catch (error) {
+      console.error('Error downloading the CSV file:', error);
+      setErrorMessage('ダウンロード中に未知のエラーが発生しました。');
+    }
   };
-  return { handleDownloadCsv };
+
+  return { errorMessage, handleDownloadCsv };
 };

--- a/apps/web/src/hooks/InventoryItems.ts
+++ b/apps/web/src/hooks/InventoryItems.ts
@@ -21,6 +21,8 @@ export const useInventoryItemState = () => {
   const itemsPerPage = 3;
   const [showRegisterModal, setShowRegisterModal] = useState(false);
   const [btnEditChangeColors, setBtnEditChangeColors] = useState<{ [key: string]: string }>({});
+  const [bulkData, setBulkData] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
 
   return {
     items,
@@ -48,5 +50,9 @@ export const useInventoryItemState = () => {
     itemsPerPage,
     btnEditChangeColors,
     setBtnEditChangeColors,
+    bulkData,
+    setBulkData,
+    successMessage,
+    setSuccessMessage,
   };
 };

--- a/apps/web/src/pages/Index.test.tsx
+++ b/apps/web/src/pages/Index.test.tsx
@@ -5,9 +5,20 @@ import { IndexPage } from './Index';
 
 const mockGet = vi.hoisted(() => vi.fn());
 const mockPut = vi.hoisted(() => vi.fn());
+const mockCsvPost = vi.hoisted(() => vi.fn());
+const mockBulkPost = vi.hoisted(() => vi.fn());
 
 vi.mock('../lib/api-client', () => ({
-  api: { api: { items: { $get: mockGet, ':id': { $put: mockPut } } } },
+  api: {
+    api: {
+      items: {
+        $get: mockGet,
+        ':id': { $put: mockPut },
+        csv: { $post: mockCsvPost },
+        bulk: { $post: mockBulkPost },
+      },
+    },
+  },
 }));
 
 // レイアウト内の Link はルーターコンテキストが必要なため、テストではアンカーに差し替える
@@ -131,6 +142,18 @@ describe('IndexPage', () => {
         },
       });
     });
+  });
+
+  it('CSVダウンロードは選択0件だとリクエストせず画面も無反応(現行仕様)', async () => {
+    mockItems([item(1)]);
+    const user = userEvent.setup();
+    render(<IndexPage />);
+    await screen.findByText('商品1');
+
+    await user.click(screen.getByRole('button', { name: 'CSVダウンロード' }));
+
+    expect(mockCsvPost).not.toHaveBeenCalled();
+    expect(screen.queryByText(/エラー/)).not.toBeInTheDocument();
   });
 
   it('取得エラー時は画面にエラーを表示しない(現行仕様の忠実再現)', async () => {

--- a/apps/web/src/pages/Index.tsx
+++ b/apps/web/src/pages/Index.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ThreeDots as Loader } from 'react-loader-spinner';
 import { DangerButton } from '../components/DangerButton';
 import { Modal } from '../components/Modal';
+import { StorageRegister } from '../components/StorageRegister';
 import { useDownloadCsv } from '../features/DownloadCsv';
 import { useEditUpdate } from '../features/EditAndUpdate';
 import { useMasterCheckbox } from '../features/MasterCheckbox';
@@ -86,8 +87,14 @@ export function IndexPage() {
                   CSVダウンロード
                 </DangerButton>
               </div>
-              {/* StorageRegister(入庫記録モーダル)は PR5 で移植。state のみ現行踏襲 */}
-              {showRegisterModal && null}
+              <StorageRegister
+                isOpen={showRegisterModal}
+                onClose={() => {
+                  setShowRegisterModal(false);
+                  fetchData();
+                }}
+                fetchData={fetchData}
+              />
             </div>
 
             <div className="overflow-hidden shadow-sm sm:rounded-lg">

--- a/apps/web/src/pages/Profile.tsx
+++ b/apps/web/src/pages/Profile.tsx
@@ -1,0 +1,31 @@
+import { UpdatePasswordForm } from '../components/UpdatePasswordForm';
+import { AuthenticatedLayout } from '../layouts/AuthenticatedLayout';
+import { authClient } from '../lib/auth-client';
+
+/**
+ * Profile(パスワード変更)画面(現行 Pages/Profile/Edit.tsx の忠実移植・縮小)。
+ * 現行で実際に描画されるのは UpdatePasswordForm のみ。名前・メール変更と退会は
+ * 死にコードのため移植しない(migration-spec.md §2.4)。
+ */
+export function ProfilePage() {
+  const { data: session } = authClient.useSession();
+
+  if (!session) {
+    return null;
+  }
+
+  return (
+    <AuthenticatedLayout
+      user={session.user}
+      header={<h2 className="text-lg font-medium text-gray-900t">パスワード更新</h2>}
+    >
+      <div className="py-12">
+        <div className="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+          <div className="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+            <UpdatePasswordForm className="max-w-xl" />
+          </div>
+        </div>
+      </div>
+    </AuthenticatedLayout>
+  );
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -8,6 +8,7 @@ import {
 import { authClient } from './lib/auth-client';
 import { IndexPage } from './pages/Index';
 import { LoginPage } from './pages/Login';
+import { ProfilePage } from './pages/Profile';
 
 const rootRoute = createRootRoute({
   component: Outlet,
@@ -33,7 +34,20 @@ const indexRoute = createRoute({
   component: IndexPage,
 });
 
-const routeTree = rootRoute.addChildren([loginRoute, indexRoute]);
+/** `/profile` = パスワード変更。未認証は `/`(ログイン)へリダイレクト。 */
+const profileRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/profile',
+  beforeLoad: async () => {
+    const { data } = await authClient.getSession();
+    if (!data) {
+      throw redirect({ to: '/' });
+    }
+  },
+  component: ProfilePage,
+});
+
+const routeTree = rootRoute.addChildren([loginRoute, indexRoute, profileRoute]);
 
 export const router = createRouter({ routeTree });
 


### PR DESCRIPTION
## 概要

#43 リプレイスの PR5(子 Issue #52)。入庫記録モーダル(StorageRegister)・CSV 出力・Profile(パスワード変更)画面を移植する。移植方針は現行挙動の忠実再現(migration-spec.md §2.3・§2.4・§3.2・§3.3)。

**⚠️ Stacked PR**: ベースは PR4 のブランチ(feature/#49-items)。**#51 → 本PR の順にマージ**してください(ベース側 PR マージ時に Delete branch を押すと本 PR のベースが自動で develop に切り替わります)。

## 変更内容

- **api**: `POST /api/items/bulk`(バリデーションなし・stock_ins 記録なし・トランザクションなし・inventoryItem 文字列のまま = 現行仕様)、`POST /api/items/csv`(UTF-8 BOM・laracsv 互換のヘッダ/クオート/登録日形式)
  - Content-Disposition の日本語ファイル名は fetch Headers の ByteString 制約で生 UTF-8 不可のため RFC 6266 形式にエンコード(フロントは download 属性のクライアント側ファイル名を使うため実害なし)
- **web**: StorageRegister モーダル(単一行 input・カンマ区切り・成功メッセージ)、DownloadCsv 実体(UTC 基準の `YYYYMM_棚卸し.csv`・選択0件/失敗時のエラー非表示 = 現行仕様)、`/profile` パスワード変更画面(Better Auth change-password、エラー時フィールドリセット+フォーカス移動、成功メッセージ2秒自動消去まで再現)

## テスト

- [x] api: 24 テスト(+bulk/CSV: BOM・クオート・空 ids・stock_ins 非記録)
- [x] web: 14 テスト(+モーダル送信ペイロード・失敗時無反応・CSV 選択0件・パスワード変更3系統)
- [x] Playwright 実機: 一括登録→一覧反映→DB 確認(**文字列 inventoryItem の pgsql 暗黙変換を実証** — 仕様書の⚠️解消)、CSV ダウンロード、パスワード変更→復元
- [x] 3観点並列レビュー→敵対的検証の確定指摘 2 件を反映(テストの実行順依存解消 / 成功メッセージ自動消去)

Refs #43 / Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)